### PR TITLE
Define EMULATOR

### DIFF
--- a/HaD_Badge.h
+++ b/HaD_Badge.h
@@ -1,5 +1,7 @@
 #include <inttypes.h>
 
+#define EMULATOR
+
 #define TOTPIXELX       8
 #define TOTPIXELY       16
 


### PR DESCRIPTION
Defines EMULATOR in HaD_Badge.h in order to make it possible to write platform-dependent code (for example debug code using libraries unavailable on the badge)
